### PR TITLE
Solve issue with executing plugin in shallow cloned Git repo

### DIFF
--- a/src/main/groovy/org/dvaske/gradle/GitBuildInfoPlugin.groovy
+++ b/src/main/groovy/org/dvaske/gradle/GitBuildInfoPlugin.groovy
@@ -30,11 +30,12 @@ package org.dvaske.gradle
 
 import org.eclipse.jgit.api.DescribeCommand
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.errors.JGitInternalException
 import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.eclipse.jgit.lib.AnyObjectId
 import org.eclipse.jgit.lib.ObjectId
-import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -95,9 +96,13 @@ class GitBuildInfo implements Plugin<Project> {
                 project.ext.gitRemote = gitRemote
                 project.ext.gitHead = head.name
 
-                DescribeCommand describe = new Git(repo).describe()
-                describe.setLong(true)
-                project.ext.gitDescribeInfo = describe.call()
+                try {
+                    DescribeCommand describe = new Git(repo).describe()
+                    describe.setLong(true)
+                    project.ext.gitDescribeInfo = describe.call()
+                } catch (JGitInternalException e) {
+                    logger.debug '`git describe` returned an error. Are you in a shallow cloned Git repository?', e
+                }
                 repo.close()
                 //logger.debug("Git repository info: HEAD: $project.gitHead, describe: project.gitDescribeInfo")
             }


### PR DESCRIPTION
The Git lib JGit throws a `JGitInternalException` if `Git#describe()` is
executed in a Git repository, which was cloned shallowly. This behavior
is expected as Git cannot find any information in the local history.

The 'gitDescribeInfo' property is set to 'NA' already if it has no
value. Just catching the exception without any further action should
therefore be sufficient.